### PR TITLE
feat(backend): Introduce handshake & extract logic auth logic to separate classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ supported configuration settings their environment variable equivalents:
 
 ```ruby
 Clerk.configure do |c|
-  c.api_key = "your_api_key" # if omitted: ENV["CLERK_API_KEY"] - API calls will fail if unset
-  c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
+  c.api_key = "your_api_key" # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
+  c.base_url = "https://..." # if omitted: ENV["CLERK_API_BASE"] - defaults to "https://api.clerk.com/v1/"
+  c.publishable_key = "pk_(test|live)_...." # if omitted: ENV["CLERK_PUBLISHABLE_KEY"] - Handshake mechanism (check section below) will fail if unset
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = ActiveSupport::Cache::FileStore.new("/tmp/clerk_middleware_cache") # if omitted: no caching
   c.excluded_routes ["/foo", "/bar/*"]
@@ -102,6 +103,7 @@ arguments to the constructor:
 clerk = Clerk::SDK.new(
     api_key: "X",
     base_url: "Y",
+    publishable_key: "Z",
     logger: Logger.new()
 )
 ```
@@ -158,6 +160,14 @@ single key (`errors`) containing an array of error objects.
 
 Read the [API documentation](https://clerk.com/docs/reference/backend-api)
 for details on expected parameters and response formats.
+
+<a name="handshake"></a>
+
+### Handshake
+
+The Client Handshake is a mechanism that is used to resolve a request’s authentication state from “unknown” to definitively signed in or signed out. Clerk’s session management architecture relies on a short-lived session JWT to validate requests, along with a long-lived session that is used to keep the session JWT fresh by interacting with the Frontend API. The long-lived session token is stored in an HttpOnly cookie associated with the Frontend API domain. If a short-lived session JWT is expired on a request to an application’s backend, the SDK doesn’t know if the session has ended, or if a new short-lived JWT needs to be issued. When an SDK gets into this state, it triggers the handshake.
+
+With the handshake, we can resolve the authentication state on the backend and ensure the request is properly handled as signed in or out, instead of being in a potentially “unknown” state. The handshake flow relies on redirects to exchange session information between FAPI and the application, ensuring the resolution of unknown authentication states minimizes performance impact and behaves consistently across different framework and language implementations.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ supported configuration settings their environment variable equivalents:
 ```ruby
 Clerk.configure do |c|
   c.api_key = "your_api_key" # if omitted: ENV["CLERK_API_KEY"] - API calls will fail if unset
-  c.base_url = "https://..." # if omitted: "https://api.clerk.dev/v1/"
+  c.base_url = "https://..." # if omitted: "https://api.clerk.com/v1/"
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = ActiveSupport::Cache::FileStore.new("/tmp/clerk_middleware_cache") # if omitted: no caching
   c.excluded_routes ["/foo", "/bar/*"]

--- a/lib/clerk.rb
+++ b/lib/clerk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "clerk/version"
+require_relative "clerk/constants"
 require_relative "clerk/sdk"
 
 module Clerk
@@ -16,7 +17,7 @@ module Clerk
 
   class Config
     PRODUCTION_BASE_URL = "https://api.clerk.dev/v1/".freeze
-    attr_accessor :api_key, :base_url, :logger, :middleware_cache_store
+    attr_accessor :api_key, :base_url, :logger, :middleware_cache_store, :publishable_key
 
     # An array of route paths on which the middleware will not execute.
     #
@@ -49,6 +50,8 @@ module Clerk
       if secret_key && !secret_key.empty?
         @api_key = secret_key
       end
+
+      @publishable_key = ENV["CLERK_PUBLISHABLE_KEY"]
 
       @excluded_routes = []
     end

--- a/lib/clerk/authenticate_context.rb
+++ b/lib/clerk/authenticate_context.rb
@@ -1,0 +1,186 @@
+require "ostruct"
+require "forwardable"
+require "base64"
+
+module Clerk
+    ##
+    # This class represents a parameter object used to contain all request and configuration
+    # information required by the middleware to resolve the current request state.
+    # link: https://refactoring.guru/introduce-parameter-object
+    class AuthenticateContext
+        extend Forwardable
+
+        ##
+        # Expose the url of the request that this parameter object was created from as a URI object.
+        attr_reader :clerk_url
+
+        ##
+        # Expose properties that does not require validations or complex logic to retrieve
+        # values by delegating them to the cookies or headers variables.
+        def_delegators :@cookies, :session_token_in_cookie, :client_uat
+        def_delegators :@headers, :session_token_in_header, :sec_fetch_dest
+
+        ##
+        # Creates a new parameter object using Rack::Request and Clerk::Config objects.
+        def initialize(request, config)
+            @clerk_url = URI.parse(request.url)
+            @config = config
+
+            @cookies = OpenStruct.new({
+                session_token_in_cookie: request.cookies[SESSION_COOKIE],
+                client_uat: request.cookies[CLIENT_UAT_COOKIE],
+                handshake_token: request.cookies[HANDSHAKE_COOKIE],
+                dev_browser: request.cookies[DEV_BROWSER_COOKIE]
+            })
+
+            @headers = OpenStruct.new({
+                session_token_in_header: request.env[AUTHORIZATION_HEADER].to_s.gsub(/bearer/i, '').strip,
+                sec_fetch_dest: request.env[SEC_FETCH_DEST_HEADER],
+                accept: request.env[ACCEPT_HEADER].to_s,
+                origin: request.env[ORIGIN_HEADER].to_s,
+                host: request.host,
+                port: request.port
+            })
+        end
+
+        ##
+        # The following properties are part of the props supported in all the AuthenticateContext
+        # objects across all of our SDKs (eg JS, Go)
+        def secret_key
+            @config.api_key.to_s
+        end
+
+        def publishable_key
+            @config.publishable_key.to_s
+        end
+
+        def domain
+            # TODO(dimkl): Add multi-domain support
+            ""
+        end
+
+        def is_satellite?
+            # TODO(dimkl): Add multi-domain support
+            false
+        end
+
+        def proxy_url
+            # TODO(dimkl): Add multi-domain support
+            ""
+        end
+
+        def handshake_token
+            @handshake_token ||= retrieve_from_query_string(@clerk_url, HANDSHAKE_COOKIE) || @cookies.handshake_token.to_s
+        end
+
+        def clerk_synced?
+            # TODO(dimkl): Add multi-domain support
+            false
+        end
+
+        def clerk_redirect_url
+             # TODO(dimkl): Add multi-domain support
+             ""
+        end
+
+        def dev_browser
+            @dev_browser ||= retrieve_from_query_string(@clerk_url, DEV_BROWSER_COOKIE) || @cookies.dev_browser.to_s
+        end
+
+        # The frontend_api returned is without protocol prefix
+        def frontend_api
+            return "" if !valid_publishable_key?(publishable_key.to_s)
+
+            @frontend_api ||= if !proxy_url.empty?
+                proxy_url
+            elsif development_instance? && !domain.empty?
+                "clerk.#{domain}"
+            else
+                # remove $ postfix
+                decode_publishable_key(publishable_key).chop
+            end
+        end
+
+        def development_instance?
+            # TODO(dimkl): Consolidate with @clerk/backend to use pk instead of sk
+            secret_key.start_with?("sk_test_")
+        end
+
+        def production_instance?
+            # TODO(dimkl): Consolidate with @clerk/backend to use pk instead of sk
+            secret_key.start_with?("sk_live_")
+        end
+
+        def document_request?
+            @headers.sec_fetch_dest == "document"
+        end
+
+        def accepts_html?
+            @headers.accept && @headers.accept.start_with?('text/html')
+        end
+        
+        def eligible_for_multi_domain?
+            is_satellite? && document_request? && !clerk_synced?
+        end
+
+        def active_client?
+            @cookies.client_uat.to_i > 0
+        end
+
+        def cross_origin_request?
+            # origin contains scheme+host and optionally port (omitted if 80 or 443)
+            # ref. https://www.rfc-editor.org/rfc/rfc6454#section-6.1
+            return false if @headers.origin.nil?
+      
+            # strip scheme
+            origin = @headers.origin.strip.sub(/\A(\w+:)?\/\//, '')
+            return false if origin.empty?
+      
+            # Rack's host and port helpers are reverse-proxy-aware; that
+            # is, they prefer the de-facto X-Forwarded-* headers if they're set
+            request_host = @headers.host
+            request_host << ":#{@headers.port}" if @headers.port != 80 && @headers.port != 443
+      
+            origin != request_host
+        end
+
+        def dev_browser?
+            !dev_browser.empty?
+        end
+
+        def session_token_in_header?
+            !session_token_in_header.to_s.empty?
+        end
+
+        def handshake_token?
+            !handshake_token.to_s.empty?
+        end
+
+        def session_token_in_cookie?
+            !session_token_in_cookie.to_s.empty?
+        end
+
+        private
+
+        def valid_publishable_key?(pk)
+            valid_publishable_key_prefix?(pk) && valid_publishable_key_postfix?(pk)
+        end
+
+        def valid_publishable_key_prefix?(pk)
+            pk.start_with?("pk_live_") || pk.start_with?("pk_test_")
+        end
+
+        def valid_publishable_key_postfix?(pk)
+            decode_publishable_key(pk).end_with?("$")
+        end
+
+        def decode_publishable_key(pk)
+            Base64.decode64(pk.split("_")[2].to_s)
+        end
+
+        def retrieve_from_query_string(url, key)
+            request_qs = Rack::Utils.parse_query(url.query)
+            request_qs[key]
+        end
+    end
+end

--- a/lib/clerk/authenticate_request.rb
+++ b/lib/clerk/authenticate_request.rb
@@ -1,0 +1,245 @@
+module Clerk
+    ##
+    # This class represents a service object used to determine the current request state
+    # for the current env passed based on a provided Clerk::AuthenticateContext.
+    # There is only 1 public method exposed (`resolve`) to be invoked with a env parameter.
+    class AuthenticateRequest
+        attr_reader :auth_context
+
+        ##
+        # Creates a new instance using Clerk::AuthenticateContext object.
+        def initialize(auth_context)
+            @auth_context = auth_context
+        end
+
+        ##
+        # Determines the current request state by verifying a Clerk token in headers or cookies.
+        # The possible outcomes of this method are `signed-in`, `signed-out` or `handshake` states.
+        # The return values are the same as a return value of a rack middleware `[http_status_code, headers, body]`.
+        # When used in a middleware the consumer of this service should return the return value when there is an
+        # `http_status_code` provided otherwise the should continue with the middleware chain.
+        # The headers provided in the return value is a hash of { header_key => header_value } and in the case
+        # of a `Set-Cookie` header the `header_value` used is a list of raw HTTP Set-Cookie directives.
+        def resolve(env)
+            if auth_context.session_token_in_header?
+                resolve_header_token(env)
+            else
+                resolve_cookie_token(env)
+            end
+        end
+
+        protected
+
+        def resolve_header_token(env)
+            begin
+                # malformed JWT
+                return signed_out(reason: TokenVerificationErrorReason::TOKEN_INVALID) if !sdk.decode_token(auth_context.session_token_in_header)
+
+                claims = verify_token(auth_context.session_token_in_header)
+                return signed_in(env, claims, auth_context.session_token_in_header) if claims
+            rescue JWT::DecodeError
+                # malformed JSON authorization header
+                return signed_out(reason: TokenVerificationErrorReason::TOKEN_INVALID)
+            rescue JWT::ExpiredSignature
+                return signed_out(enforce_auth: true, reason: TokenVerificationErrorReason::TOKEN_EXPIRED)
+            rescue JWT::InvalidIatError
+                return signed_out(enforce_auth: true, reason: TokenVerificationErrorReason::TOKEN_NOT_ACTIVE_YET)
+            end
+
+            # Clerk.js should refresh the token and retry
+            return signed_out(enforce_auth: true)
+        end
+
+        def resolve_cookie_token(env)
+            # in cross-origin XHRs the use of Authorization header is mandatory.
+            # TODO: add reason
+            return signed_out if auth_context.cross_origin_request?
+
+            if auth_context.handshake_token?
+                return resolve_handshake(env)
+            end
+
+            if auth_context.development_instance? && auth_context.dev_browser?
+                return handle_handshake_maybe_status(env, reason: AuthErrorReason::DEV_BROWSER_SYNC)
+            end
+
+            # TODO(dimkl): Add multi-domain support for production
+            # if auth_context.production_instance? && auth_context.eligible_for_multi_domain?
+                # return handle_handshake_maybe_status(env, reason: AuthErrorReason::SATELLITE_COOKIE_NEEDS_SYNCING)
+            # end
+
+            # TODO(dimkl): Add multi-domain support for development
+            # if auth_context.development_instance? && auth_context.eligible_for_multi_domain?
+                # trigger handshake using auth_context.sign_in_url as base redirect_url
+                # return handle_handshake_maybe_status(env, reason: AuthErrorReason::SATELLITE_COOKIE_NEEDS_SYNCING, '', headers);
+            # end
+
+            # TODO(dimkl): Add multi-domain support for development in primary
+            # if auth_context.development_instance? && !auth_context.is_satellite? && auth_context.clerk_redirect_url
+                # trigger handshake using auth_context.clerk_redirect_url as base redirect_url + mark it as clerk_synced
+                # return handle_handshake_maybe_status(env, reason: AuthErrorReason::PRIMARY_RESPONDS_TO_SYNCING, '', headers);
+            # end
+
+            if !auth_context.active_client? && !auth_context.session_token_in_cookie?
+                return signed_out(reason: AuthErrorReason::SESSION_TOKEN_AND_UAT_MISSING)
+            end
+
+            # This can eagerly run handshake since client_uat is SameSite=Strict in dev
+            if !auth_context.active_client? && auth_context.session_token_in_cookie?
+                return handle_handshake_maybe_status(env, reason: AuthErrorReason::SESSION_TOKEN_WITHOUT_CLIENT_UAT)
+            end
+
+            if auth_context.active_client? && !auth_context.session_token_in_cookie?
+                return handle_handshake_maybe_status(env, reason: AuthErrorReason::CLIENT_UAT_WITHOUT_SESSION_TOKEN)
+            end
+
+            begin
+                token = verify_token(auth_context.session_token_in_cookie)
+                return signed_out if !token
+
+                if token["iat"] < auth_context.client_uat
+                    return handle_handshake_maybe_status(env, reason: AuthErrorReason::SESSION_TOKEN_OUTDATED);
+                end
+
+                return signed_in(env, token, auth_context.session_token_in_cookie)
+            rescue JWT::ExpiredSignature
+                handshake(env, reason: TokenVerificationErrorReason::TOKEN_EXPIRED)
+            rescue JWT::InvalidIatError
+                handshake(env, reason: TokenVerificationErrorReason::TOKEN_NOT_ACTIVE_YET)
+            end
+
+            signed_out
+        end
+
+        def resolve_handshake(env)
+            headers = { 
+                "Access-Control-Allow-Origin" => "null",
+                "Access-Control-Allow-Credentials" => "true"
+            }
+            
+            session_token = ''
+
+            handshake_payload = verify_token(auth_context.handshake_token)
+            return signed_out(enforce_auth: true, reason: TokenVerificationErrorReason::JWK_FAILED_TO_RESOLVE) if !handshake_payload
+
+            cookies_to_set = handshake_payload[HANDSHAKE_COOKIE_DIRECTIVES_KEY] || []
+            cookies_to_set.each do |cookie|
+                headers[COOKIE_HEADER] ||= []
+                headers[COOKIE_HEADER] << cookie
+
+                if cookie.start_with?("#{SESSION_COOKIE}=")
+                    session_token = cookie.split(';')[0].split('=')[1]
+                end
+            end
+
+            if auth_context.development_instance?
+                redirect_url = auth_context.clerk_url.dup
+                remove_from_query_string(redirect_url, HANDSHAKE_COOKIE)
+                remove_from_query_string(redirect_url, HANDSHAKE_HELP_QUERY_PARAM)
+
+                headers[LOCATION_HEADER] = redirect_url.to_s
+            end
+            
+            if !session_token
+                return signed_out(reason: AuthErrorReason::SESSION_TOKEN_MISSING, headers: headers)
+            end
+
+            begin
+                claims = verify_token(session_token)
+                return signed_in(env, claims, session_token) if claims
+            rescue JWT::ExpiredSignature, JWT::InvalidIatError => e
+                if auth_context.development_instance?
+                    # TODO: log possible Clock skew detected
+                
+                    # Retry with a generous clock skew allowance (1 day)
+                    claims = verify_token(session_token, timeout: 86_400)
+                    return signed_in(env, claims, session_token) if claims
+                end
+                
+                # Raise error if handshake resolution fails in production
+                raise e
+            end
+        end
+
+        def handle_handshake_maybe_status(env, **opts)
+            return signed_out if !eligible_for_handshake?
+            handshake(env, **opts)
+        end
+
+        # A outcome
+        def handshake(env, **opts)
+            redirect_headers = { LOCATION_HEADER => redirect_to_handshake }
+            [307, debug_auth_headers(**opts).merge(redirect_headers), []]
+        end
+
+        # B outcome
+        def signed_out(**opts)
+            headers = opts.delete(:headers) || {}
+            enforce_auth = opts.delete(:enforce_auth)
+
+            if enforce_auth
+                [401, debug_auth_headers(**opts).merge(headers), []]
+            else
+                [nil, headers, []]
+            end
+        end
+
+        # C outcome
+        def signed_in(env, claims, token, **headers)
+            env["clerk"] = ProxyV2.new(session_claims: claims, session_token: token)
+            [nil, headers, []]
+        end
+
+        def eligible_for_handshake?
+            auth_context.document_request? || (!auth_context.document_request? && auth_context.accepts_html?)
+        end
+
+        private
+
+        def redirect_to_handshake
+            redirect_url = auth_context.clerk_url.dup
+            remove_from_query_string(redirect_url, DEV_BROWSER_COOKIE)
+
+            handshake_url = URI.parse("https://#{auth_context.frontend_api}/v1/client/handshake")
+            handshake_url_qs = Rack::Utils.parse_query(handshake_url.query)
+            handshake_url_qs["redirect_url"] = redirect_url
+
+            if auth_context.development_instance? && auth_context.dev_browser?
+                handshake_url_qs[DEV_BROWSER_COOKIE] = auth_context.dev_browser
+            end
+
+            handshake_url.query = handshake_url_qs.to_query
+            handshake_url.to_s
+        end
+
+        def remove_from_query_string(url, key)
+            qs = Rack::Utils.parse_query(url.query)
+            qs.delete(key)
+            url.query = qs.to_query
+        end
+
+        def verify_token(token, **opts)
+            return false if token.nil? || token.strip.empty?
+        
+            begin
+                sdk.verify_token(token, **opts)
+            rescue JWT::ExpiredSignature, JWT::InvalidIatError => e
+                raise e
+            rescue JWT::DecodeError, JWT::RequiredDependencyError => e
+                false
+            end
+        end
+
+        def sdk
+            Clerk::SDK.new
+        end
+    
+        def debug_auth_headers(reason: nil, message: nil, status: nil)
+            {
+                AUTH_REASON_HEADER => reason,
+                AUTH_MESSAGE_HEADER => message,
+                AUTH_STATUS_HEADER => status,
+            }.compact
+        end
+    end
+end

--- a/lib/clerk/constants.rb
+++ b/lib/clerk/constants.rb
@@ -1,0 +1,50 @@
+module Clerk
+    SESSION_COOKIE = "__session".freeze
+    CLIENT_UAT_COOKIE = "__client_uat".freeze
+    
+    # Dev Browser
+    DEV_BROWSER_COOKIE = "__clerk_db_jwt".freeze
+
+    # Handshake
+    HANDSHAKE_COOKIE = "__clerk_handshake".freeze
+    HANDSHAKE_HELP_QUERY_PARAM = "__clerk_help".freeze
+    HANDSHAKE_COOKIE_DIRECTIVES_KEY = "handshake".freeze
+
+    # auth debug response headers
+    AUTH_STATUS_HEADER = "X-Clerk-Auth-Status".freeze
+    AUTH_REASON_HEADER = "X-Clerk-Auth-Reason".freeze
+    AUTH_MESSAGE_HEADER = "X-Clerk-Auth-Message".freeze
+
+    #
+    CONTENT_TYPE_HEADER = "Content-Type".freeze
+    SEC_FETCH_DEST_HEADER = "HTTP_SEC_FETCH_DEST".freeze
+    
+    # headers used in response - should be lowered case and without http prefix
+    LOCATION_HEADER = "Location".freeze
+    COOKIE_HEADER = "Set-Cookie".freeze
+
+    # clerk url related headers
+    AUTHORIZATION_HEADER = "HTTP_AUTHORIZATION".freeze
+    ACCEPT_HEADER = "HTTP_ACCEPT".freeze
+    USER_AGENT_HEADER = "HTTP_USER_AGENT".freeze
+    ORIGIN_HEADER = "HTTP_ORIGIN".freeze
+
+    module TokenVerificationErrorReason
+        TOKEN_INVALID = "token-invalid".freeze
+        TOKEN_EXPIRED = "token-expired".freeze
+        TOKEN_NOT_ACTIVE_YET = "token-not-active-yet".freeze
+        JWK_FAILED_TO_RESOLVE = "jwk-failed-to-resolve".freeze
+    end
+
+    module AuthErrorReason
+        CLIENT_UAT_WITHOUT_SESSION_TOKEN = "client-uat-but-no-session-token".freeze
+        DEV_BROWSER_SYNC = "dev-browser-sync".freeze
+        PRIMARY_RESPONDS_TO_SYNCING = "primary-responds-to-syncing".freeze
+        SATELLITE_COOKIE_NEEDS_SYNCING = "satellite-needs-syncing".freeze
+        SESSION_TOKEN_AND_UAT_MISSING = "session-token-and-uat-missing".freeze
+        SESSION_TOKEN_MISSING = "session-token-missing".freeze
+        SESSION_TOKEN_OUTDATED = "session-token-outdated".freeze
+        SESSION_TOKEN_WITHOUT_CLIENT_UAT = "session-token-but-no-client-uat".freeze
+        UNEXPECTED_ERROR = "unexpected-error".freeze
+    end
+end

--- a/lib/clerk/rack_middleware.rb
+++ b/lib/clerk/rack_middleware.rb
@@ -17,7 +17,7 @@ module Clerk
     attr_reader :session_id, :error
     def initialize(env)
       req = Rack::Request.new(env)
-      @token = req.cookies["__session"]
+      @token = req.cookies[SESSION_COOKIE]
       @session_id = req.params["_clerk_session_id"]
       @session = nil
       @user_id = nil

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -96,7 +96,7 @@ module Clerk
                    end
                  end
 
-      body = if response["Content-Type"] == "application/json"
+      body = if response[CONTENT_TYPE_HEADER] == "application/json"
                JSON.parse(response.body)
              else
                response.body
@@ -155,10 +155,6 @@ module Clerk
       Resources::JWKS.new(self)
     end
 
-    def interstitial(refresh=false)
-      request(:get, "internal/interstitial")
-    end
-
     # Returns the decoded JWT payload without verifying if the signature is
     # valid.
     #
@@ -185,7 +181,7 @@ module Clerk
         { keys: SDK.jwks_cache.fetch(self, kid_not_found: (options[:invalidate] || options[:kid_not_found]), force_refresh: force_refresh_jwks) }
       end
 
-      JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwk_loader).first
+      JWT.decode(token, nil, true, algorithms: algorithms, exp_leeway: timeout, jwks: jwk_loader).first
     end
   end
 end


### PR DESCRIPTION
## Changes made in this PR

- Drop `Clerk::SDK#interstitial` method (it should not be used by any customer since this is internal)
- Replace the interstitial mechanism with the handshake mechanism
- Extract logic from the RackMiddlewareV2 to `AuthenticateRequest` class
- Extract data used from the request and the configuration to `AuthenticateContext` class ([Parameter object pattern](https://refactoring.guru/introduce-parameter-object))
- Introduce constants module to centralize and re-use the constants value used across the SDK

## Customer impact
- Interstitial HTML page rendered when we cannot determine the request state is replaced with 2 HTTP 307 redirects
- Introduced `CLERK_PUBLISHABLE_KEY` env which is required for the handshake to work properly
- `CLERK_SECRET_KEY` should use the format `sk_test | sk_live` format

## TODO
- Add tests
- Check all uses cases

## Next Steps

- Support multi-domain logic

