### PR TITLE
Prepare for 4.0.0.beta2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 
-## 4.0.0.beta1 - 2024-02-26
+## 4.0.0.beta2 - 2024-02-26
+
+Note: this is identical to 4.0.0.beta1, which was yanked because it was not generated from the main branch.
+
+- feat: replace interstitial with handshake (internal mechanisms) [https://github.com/clerk/clerk-sdk-ruby/pull/45]
+- chore: re-organize and refactor internal code to extract functionality of rack middleware [https://github.com/clerk/clerk-sdk-ruby/pull/45]
+- changed: `CLERK_PUBLISHABLE_KEY` or `publishable_key` in `Clerk.configure` is **required** [https://github.com/clerk/clerk-sdk-ruby/pull/46]
+
+## [YANKED] 4.0.0.beta1 - 2024-02-26
 
 - feat: replace interstitial with handshake (internal mechanisms) [https://github.com/clerk/clerk-sdk-ruby/pull/45]
 - chore: re-organize and refactor internal code to extract functionality of rack middleware [https://github.com/clerk/clerk-sdk-ruby/pull/45]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (4.0.0.beta1)
+    clerk-sdk-ruby (4.0.0.beta2)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 To release a new version:
 - update the version number in `version.rb`
+- update `CHANGELOG.md` to include information about the changes
+- merge changes into main
 - run `bundle exec rake release`
 
 If gem publishing is NOT executed automatically:

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "4.0.0.beta1"
+  VERSION = "4.0.0.beta2"
 end


### PR DESCRIPTION
Generating new beta release since i yanked the `4.0.0.beta1` because the gem was published from a branch