### PR TITLE
fix: Incompatible __client_uat & __session should show interstitial

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (2.11.1)
+    clerk-sdk-ruby (3.1.0.rc.1)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -166,13 +166,20 @@ module Clerk
       #                             COOKIE AUTHENTICATION                      #
       #                                                                        #
       ##########################################################################
+
       if development_or_staging? && (req.referrer.nil? || cross_origin_request?(req))
         return unknown(interstitial: true)
       end
 
-      if production? && client_uat.nil?
-        return signed_out(env)
+      # Show interstitial when there is no client_uat and cookie token
+      if client_uat.to_s.empty? && cookie_token.to_s.empty?
+        return unknown(interstitial: true)
       end
+
+      # Show interstitial when there is client_uat is incompatible with cookie token
+      has_cookie_token_without_client = (client_uat == "0" || client_uat.to_s.empty?) && cookie_token
+      has_client_without_cookie_token = (client_uat.to_s != "0" || client_uat.to_s != "") && cookie_token.to_s.empty?
+      return unknown(interstitial: true) if has_cookie_token_without_client || has_client_without_cookie_token
 
       if client_uat == "0"
         return signed_out(env)

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "3.0.0"
+  VERSION = "3.1.0.rc.1"
 end


### PR DESCRIPTION
Handle 2 interstitial cases:
- when there is `client_uat` and `cookie token` info (both for dev and production apps)
- when `client_uat` has a value that does not match with the `cookie token` value
  - client_uat = 0 (signed-out) but cookie token has value (signed-in)
  - client_uat does NOT have value (??) but cookie token has value (signed-in)
  - client_uat = 123... (signed-in) but cookie token does NOT havue value (signed-out)
