### PR TITLE
fix: Release version 3.1.0 with production instance hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## unreleased
 
+## 3.1.0 - 2024-03-19
+
+- fix: Incompatible __client_uat & __session should show interstitial (#51) [https://github.com/clerk/clerk-sdk-ruby/pull/51]
+- fix: Incorrect check that lead to infinite redirect loop introduced by (#51) [https://github.com/clerk/clerk-sdk-ruby/pull/51]
+
+
 ## 3.0.0 - 2024-01-09
 
 Note: this is identical to 2.12.0, which was yanked because it contained a

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -178,7 +178,7 @@ module Clerk
 
       # Show interstitial when there is client_uat is incompatible with cookie token
       has_cookie_token_without_client = (client_uat == "0" || client_uat.to_s.empty?) && cookie_token
-      has_client_without_cookie_token = (client_uat.to_s != "0" || client_uat.to_s != "") && cookie_token.to_s.empty?
+      has_client_without_cookie_token = (client_uat.to_s != "0" && client_uat.to_s != "") && cookie_token.to_s.empty?
       return unknown(interstitial: true) if has_cookie_token_without_client || has_client_without_cookie_token
 
       if client_uat == "0"

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "3.1.0.rc.1"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
- Bumps the version to v3.1.0
- Applies fix to v3.1.0.rc.1 which lead to infinite redirect loop (introduced in v3.1.0.rc.1)