### PR TITLE
Prepare for 4.0.0.beta3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.0.beta3 - 2024-04-02
+
+- fix: Make publishable_key and secret_key required without making the envs required [https://github.com/clerk/clerk-sdk-ruby/pull/53]
 
 ## 4.0.0.beta2 - 2024-02-26
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (4.0.0.beta2)
+    clerk-sdk-ruby (4.0.0.beta3)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "4.0.0.beta2"
+  VERSION = "4.0.0.beta3"
 end


### PR DESCRIPTION
- fix: Make publishable_key and secret_key required without making the envs required [https://github.com/clerk/clerk-sdk-ruby/pull/53]