### PR TITLE
fix: Always return signed-out when client_uat=0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (3.1.0.rc.1)
+    clerk-sdk-ruby (3.2.0)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)

--- a/lib/clerk/rack_middleware_v2.rb
+++ b/lib/clerk/rack_middleware_v2.rb
@@ -176,14 +176,14 @@ module Clerk
         return unknown(interstitial: true)
       end
 
-      # Show interstitial when there is client_uat is incompatible with cookie token
-      has_cookie_token_without_client = (client_uat == "0" || client_uat.to_s.empty?) && cookie_token
-      has_client_without_cookie_token = (client_uat.to_s != "0" && client_uat.to_s != "") && cookie_token.to_s.empty?
-      return unknown(interstitial: true) if has_cookie_token_without_client || has_client_without_cookie_token
-
       if client_uat == "0"
         return signed_out(env)
       end
+
+      # Show interstitial when there is client_uat is incompatible with cookie token
+      has_cookie_token_without_client = client_uat.to_s.empty? && cookie_token
+      has_client_without_cookie_token = client_uat.to_s != "" && cookie_token.to_s.empty?
+      return unknown(interstitial: true) if has_cookie_token_without_client || has_client_without_cookie_token
 
       begin
         token = verify_token(cookie_token)

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
This change fixes an infinite redirect issue when a user is signed-out but the `__session` cookie still exists with value.
The above scenario can be reproduced by using sign-out from Account Portal and then refresh a page of the app.