### PR TITLE
chore: Use secret_key vs api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then you can instantiate a `Clerk::SDK` instance and access all
 Here's a quick example:
 
 ```ruby
-clerk = Clerk::SDK.new(api_key: "your_api_key")
+clerk = Clerk::SDK.new(secret_key: "your_clerk_secret_key")
 # List all users
 clerk.users.all
 # Get your first user
@@ -87,9 +87,9 @@ supported configuration settings their environment variable equivalents:
 
 ```ruby
 Clerk.configure do |c|
-  c.api_key = "your_api_key" # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
   c.base_url = "https://..." # if omitted: ENV["CLERK_API_BASE"] - defaults to "https://api.clerk.com/v1/"
   c.publishable_key = "pk_(test|live)_...." # if omitted: ENV["CLERK_PUBLISHABLE_KEY"] - Handshake mechanism (check section below) will fail if unset
+  c.secret_key = "your_clerk_secret_key" # if omitted: ENV["CLERK_SECRET_KEY"] - API calls will fail if unset
   c.logger = Logger.new(STDOUT) # if omitted, no logging
   c.middleware_cache_store = ActiveSupport::Cache::FileStore.new("/tmp/clerk_middleware_cache") # if omitted: no caching
   c.excluded_routes ["/foo", "/bar/*"]
@@ -101,7 +101,7 @@ arguments to the constructor:
 
 ```ruby
 clerk = Clerk::SDK.new(
-    api_key: "X",
+    secret_key: "X",
     base_url: "Y",
     logger: Logger.new()
 )

--- a/lib/clerk.rb
+++ b/lib/clerk.rb
@@ -17,7 +17,7 @@ module Clerk
 
   class Config
     PRODUCTION_BASE_URL = "https://api.clerk.dev/v1/".freeze
-    attr_accessor :api_key, :base_url, :publishable_key, :logger, :middleware_cache_store
+    attr_accessor :base_url, :publishable_key, :secret_key, :logger, :middleware_cache_store
 
     # An array of route paths on which the middleware will not execute.
     #
@@ -44,11 +44,11 @@ module Clerk
 
     def initialize
       @base_url = ENV.fetch("CLERK_API_BASE", PRODUCTION_BASE_URL)
-      @api_key = ENV["CLERK_API_KEY"]
+      @secret_key = ENV["CLERK_API_KEY"]
 
       secret_key = ENV["CLERK_SECRET_KEY"]
       if secret_key && !secret_key.empty?
-        @api_key = secret_key
+        @secret_key = secret_key
       end
 
       @publishable_key = ENV["CLERK_PUBLISHABLE_KEY"]

--- a/lib/clerk/authenticate_context.rb
+++ b/lib/clerk/authenticate_context.rb
@@ -50,9 +50,9 @@ module Clerk
     # The following properties are part of the props supported in all the AuthenticateContext
     # objects across all of our SDKs (eg JS, Go)
     def secret_key
-      raise Errors::Configuration, 'Clerk secret key is not set' if @config.api_key.to_s.empty?
+      raise Errors::Configuration, 'Clerk secret key is not set' if @config.secret_key.to_s.empty?
 
-      @config.api_key.to_s
+      @config.secret_key.to_s
     end
 
     def publishable_key

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -37,7 +37,7 @@ module Clerk
       @@jwks_cache
     end
 
-    def initialize(api_key: nil, base_url: nil, logger: nil, ssl_verify: true,
+    def initialize(secret_key: nil, base_url: nil, logger: nil, ssl_verify: true,
                    connection: nil)
       if connection
         # Inject a Faraday::Connection for testing or full control over Faraday
@@ -51,10 +51,10 @@ module Clerk
                      URI(base_url)
                    end
 
-        api_key ||= Clerk.configuration.api_key
+        secret_key ||= Clerk.configuration.secret_key
 
-        if Faraday::VERSION.to_i >= 2 && api_key.nil?
-          api_key = -> { raise ArgumentError, "Clerk secret key is not set" }
+        if Faraday::VERSION.to_i >= 2 && secret_key.nil?
+          secret_key = -> { raise ArgumentError, "Clerk secret key is not set" }
         end
 
         logger = logger || Clerk.configuration.logger
@@ -62,7 +62,7 @@ module Clerk
           url: base_uri, headers: DEFAULT_HEADERS, ssl: {verify: ssl_verify}
         ) do |f|
           f.request :url_encoded
-          f.request :authorization, "Bearer", api_key
+          f.request :authorization, "Bearer", secret_key
           if logger
             f.response :logger, logger do |l|
               l.filter(/(Authorization: "Bearer) (\w+)/, '\1 [SECRET]')

--- a/test/sdk_test.rb
+++ b/test/sdk_test.rb
@@ -35,7 +35,7 @@ class Clerk::SdkTest < Minitest::Test
     assert_equal "user_1", user["id"]
   end
 
-  def test_no_api_key_raises_on_api_call
+  def test_no_secret_key_raises_on_api_call
     sdk = ::Clerk::SDK.new
     assert_raises ArgumentError do
       sdk.users.find("x")


### PR DESCRIPTION
Update the Ruby SDK to use the correct nomenclature of `secret_key` (vs `api_key`)

Fixes ECO-177