### PR TITLE
repo: Expand scope of reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @clerk/engineering-backend


### PR DESCRIPTION
More teams will have their hands in this repo. As such, it makes sense to remove the strict requirement of the backend team as required reviewers.

Similarly to `clerk/javascript`, I opted to remove it entirely to reduce unnecessary noise.