### PR TITLE
feat: Updates relative to clerk-http-client@2.0.0.beta5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_FROZEN: false
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     clerk-sdk-ruby (4.0.0.beta4)
-      clerk-http-client (~> 0.0.1)
+      clerk-http-client (= 2.0.0.beta5)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)
@@ -45,7 +45,7 @@ GEM
     bigdecimal (3.1.9)
     builder (3.3.0)
     byebug (11.1.3)
-    clerk-http-client (0.0.1)
+    clerk-http-client (2.0.0.beta5)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart
       marcel

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 1.4.1", "< 3.0"
   spec.add_dependency "jwt", '~> 2.5'
-  spec.add_dependency "clerk-http-client", "~> 0.0.1"
+  spec.add_dependency "clerk-http-client", "2.0.0.beta5"
   spec.add_dependency "concurrent-ruby", "~> 1.1"
 
   spec.add_development_dependency "byebug", "~> 11.1"

--- a/lib/clerk/jwks_cache.rb
+++ b/lib/clerk/jwks_cache.rb
@@ -22,7 +22,7 @@ module Clerk
         @lock.with_write_lock do
           @last_update = Time.now.to_i
           @jwks = begin
-            sdk.jwks.get.keys.map(&:to_hash)
+            sdk.jwks.get_jwks.keys.map(&:to_hash)
           rescue Clerk::Error, ClerkHttpClient::ApiError
             nil
           end

--- a/lib/clerk/proxy.rb
+++ b/lib/clerk/proxy.rb
@@ -108,13 +108,13 @@ module Clerk
 
     def fetch_user(user_id)
       cached_fetch("clerk:user:#{user_id}") do
-        sdk.users.find(user_id)
+        sdk.users.get_user(user_id)
       end
     end
 
     def fetch_org(org_id)
       cached_fetch("clerk:org:#{org_id}") do
-        sdk.organizations.find(org_id)
+        sdk.organizations.get_organization(org_id)
       end
     end
 

--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -43,34 +43,5 @@ module Clerk
 
       JWT.decode(token, nil, true, algorithms: algorithms, exp_leeway: timeout, jwks: jwk_loader).first
     end
-
-    private
-
-    # TODO: Temporary solution until generators are improved
-    HTTP_CLIENT_CUSTOM_MAPPING = {
-      allowlist: "AllowListBlockList",
-      blocklist: "AllowListBlockList",
-      email_sms_templates: "EmailSMSTemplates",
-      oauth_applications: "OAuthApplications",
-      jwt_templates: "JWTTemplates",
-      redirect_urls: "RedirectURLs",
-      saml_connections: "SAMLConnections"
-    }
-
-    def generate_const_name(method_name)
-      "#{HTTP_CLIENT_CUSTOM_MAPPING[method_name] || Utils.camel_case(method_name)}Api"
-    end
-
-    def respond_to_missing?(method_name, include_private = false)
-      ClerkHttpClient.const_get(generate_const_name(method_name)).respond_to?(:new)
-    rescue NameError
-      false
-    end
-
-    def method_missing(method_name, *arguments)
-      ClerkHttpClient.const_get(generate_const_name(method_name)).new
-    rescue NameError
-      raise NoMethodError, "undefined method `#{method_name}` for #{self.class.name}"
-    end
   end
 end

--- a/lib/clerk/utils.rb
+++ b/lib/clerk/utils.rb
@@ -5,12 +5,6 @@ require "base64"
 module Clerk
   module Utils
     class << self
-      def camel_case(str)
-        str = str.to_s
-        return str if str !~ /_/ && str =~ /[A-Z]+.*/
-        str.split("_").map { |s| s.capitalize }.join
-      end
-
       def decode_publishable_key(publishable_key)
         Base64.decode64(publishable_key.split("_")[2].to_s)
       end

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "4.0.0.beta4"
+  VERSION = "4.0.0.beta5"
 end

--- a/spec/clerk/jwks_cache_spec.rb
+++ b/spec/clerk/jwks_cache_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Clerk::JWKSCache do
 
   before do
     allow(sdk).to receive(:jwks).and_return(jwks_api)
-    allow(jwks_api).to receive(:get).and_return(double(keys: mock_keys))
+    allow(jwks_api).to receive(:get_jwks).and_return(double(keys: mock_keys))
   end
 
   describe "#fetch" do
@@ -21,43 +21,43 @@ RSpec.describe Clerk::JWKSCache do
 
     it "returns cached result on subsequent calls within lifetime" do
       first_result = cache.fetch(sdk)
-      expect(jwks_api).to have_received(:get).once
+      expect(jwks_api).to have_received(:get_jwks).once
 
       second_result = cache.fetch(sdk)
       expect(second_result).to eq(first_result)
-      expect(jwks_api).to have_received(:get).once
+      expect(jwks_api).to have_received(:get_jwks).once
     end
 
     it "refreshes cache when force_refresh is true" do
       cache.fetch(sdk)
-      expect(jwks_api).to have_received(:get).once
+      expect(jwks_api).to have_received(:get_jwks).once
 
       cache.fetch(sdk, force_refresh: true)
-      expect(jwks_api).to have_received(:get).twice
+      expect(jwks_api).to have_received(:get_jwks).twice
     end
 
     it "refreshes cache when lifetime has expired" do
       cache.fetch(sdk)
-      expect(jwks_api).to have_received(:get).once
+      expect(jwks_api).to have_received(:get_jwks).once
 
       allow(Time).to receive(:now).and_return(Time.now + lifetime + 1)
 
       cache.fetch(sdk)
-      expect(jwks_api).to have_received(:get).twice
+      expect(jwks_api).to have_received(:get_jwks).twice
     end
 
     it "refreshes cache when kid_not_found is true and last update was over 5 minutes ago" do
       cache.fetch(sdk)
-      expect(jwks_api).to have_received(:get).once
+      expect(jwks_api).to have_received(:get_jwks).once
 
       allow(Time).to receive(:now).and_return(Time.now + 301) # 5 minutes + 1 second
 
       cache.fetch(sdk, kid_not_found: true)
-      expect(jwks_api).to have_received(:get).twice
+      expect(jwks_api).to have_received(:get_jwks).twice
     end
 
     it "returns nil when API call fails" do
-      allow(jwks_api).to receive(:get).and_raise(ClerkHttpClient::ApiError)
+      allow(jwks_api).to receive(:get_jwks).and_raise(ClerkHttpClient::ApiError)
 
       result = cache.fetch(sdk)
       expect(result).to be_nil

--- a/spec/clerk/proxy_spec.rb
+++ b/spec/clerk/proxy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Clerk::Proxy do
     let(:user_object) { double("User") }
 
     before do
-      allow(sdk_double).to receive_message_chain(:users, :find).with(user_id).and_return(user_object)
+      allow(sdk_double).to receive_message_chain(:users, :get_user).with(user_id).and_return(user_object)
     end
 
     it "returns nil when not authenticated" do
@@ -80,7 +80,7 @@ RSpec.describe Clerk::Proxy do
     let(:org_object) { double("Organization") }
 
     before do
-      allow(sdk_double).to receive_message_chain(:organizations, :find).with(org_id).and_return(org_object)
+      allow(sdk_double).to receive_message_chain(:organizations, :get_organization).with(org_id).and_return(org_object)
     end
 
     it "returns nil when no organization" do

--- a/spec/clerk/sdk_spec.rb
+++ b/spec/clerk/sdk_spec.rb
@@ -107,12 +107,12 @@ RSpec.describe Clerk::SDK do
     end
   end
 
-  describe "SDK helpers" do
+  describe "SDK helper availability" do
+    # Litmus test
     {
       actor_tokens: ClerkHttpClient::ActorTokensApi,
-      allowlist: ClerkHttpClient::AllowListBlockListApi,
+      allow_list_block_list: ClerkHttpClient::AllowListBlockListApi,
       beta_features: ClerkHttpClient::BetaFeaturesApi,
-      blocklist: ClerkHttpClient::AllowListBlockListApi,
       clients: ClerkHttpClient::ClientsApi,
       domains: ClerkHttpClient::DomainsApi,
       email_addresses: ClerkHttpClient::EmailAddressesApi,
@@ -123,7 +123,6 @@ RSpec.describe Clerk::SDK do
       jwt_templates: ClerkHttpClient::JWTTemplatesApi,
       miscellaneous: ClerkHttpClient::MiscellaneousApi,
       oauth_applications: ClerkHttpClient::OAuthApplicationsApi,
-      organization_domain: ClerkHttpClient::OrganizationDomainApi,
       organization_domains: ClerkHttpClient::OrganizationDomainsApi,
       organization_invitations: ClerkHttpClient::OrganizationInvitationsApi,
       organization_memberships: ClerkHttpClient::OrganizationMembershipsApi,
@@ -137,19 +136,14 @@ RSpec.describe Clerk::SDK do
       sign_ups: ClerkHttpClient::SignUpsApi,
       testing_tokens: ClerkHttpClient::TestingTokensApi,
       users: ClerkHttpClient::UsersApi,
+      waitlist_entries: ClerkHttpClient::WaitlistEntriesApi,
       webhooks: ClerkHttpClient::WebhooksApi
     }.each do |method, instance_class|
       it "##{method} returns an instance of #{instance_class}" do
-        expect(clerk_client.send(:respond_to?, method)).to be true
         expect(clerk_client.send(method)).to be_an_instance_of(instance_class)
       end
     end
-
-    it "should appropriately report on methods that are not implemented" do
-      expect(clerk_client.respond_to?(:foo)).to be false
-      expect {
-        clerk_client.foo
-      }.to raise_error(NoMethodError, "undefined method `foo` for #{clerk_client.class.name}")
-    end
   end
 end
+
+


### PR DESCRIPTION
- Removes the need for `.respond_to_missing?` / `.method_missing` thanks to improved generation flows in the OpenAPI Java generators.
- More-closely maps the OAS versus creating our own method names to reduce overall long-term maintainance.