### PR TITLE
feat: Skippable Railties & Release Flow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (4.0.0.beta4)
+    clerk-sdk-ruby (4.0.0.beta6)
       clerk-http-client (= 2.0.0.beta5)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)

--- a/README.md
+++ b/README.md
@@ -166,9 +166,18 @@ end
 
 This gives your controller and views access to the following methods and more:
 
+- `clerk.sdk.*`
 - `clerk.session`
 - `clerk.user`
 - `clerk.user?`
+
+### Skipping the Railtie
+
+There are cases where you might not want to use the Railtie, for example, only using the SDK in a Rails application. To accomplish this, you can set the `CLERK_SKIP_RAILTIE` environment variable to `true`.
+
+This will prevent the Railtie from being loaded and the Rack middleware from being added to the middleware stack.
+
+You can still configure the SDK as normal, but you will need to call the SDK using `Clerk::SDK.new` instead of the `clerk.sdk` helper.
 
 ## Sinatra integration
 

--- a/apps/rails-api/Gemfile.lock
+++ b/apps/rails-api/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    clerk-sdk-ruby (4.0.0.beta4)
-      clerk-http-client (~> 0.0.1)
+    clerk-sdk-ruby (4.0.0.beta6)
+      clerk-http-client (= 2.0.0.beta5)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)
@@ -93,7 +93,7 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
-    clerk-http-client (0.0.1)
+    clerk-http-client (2.0.0.beta5)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart
       marcel

--- a/apps/rails-full/Gemfile.lock
+++ b/apps/rails-full/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../..
   specs:
-    clerk-sdk-ruby (4.0.0.beta4)
-      clerk-http-client (~> 0.0.1)
+    clerk-sdk-ruby (4.0.0.beta6)
+      clerk-http-client (= 2.0.0.beta5)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
       jwt (~> 2.5)
@@ -105,7 +105,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    clerk-http-client (0.0.1)
+    clerk-http-client (2.0.0.beta5)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart
       marcel

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail
+IFS=$'\n\t'
+
+# Get the version number from the generated version file
+VERSION=$(ruby -e "require './lib/clerk/version.rb'; puts Clerk::VERSION")
+
+echo "Building and releasing version ${VERSION}"
+
+# Remove any existing gem files
+rm clerk-sdk-ruby-*.gem || true
+
+# Build the gem
+gem build clerk-sdk-ruby.gemspec
+
+# Publish to RubyGems
+gem push "clerk-sdk-ruby-${VERSION}.gem"
+

--- a/lib/clerk/rails.rb
+++ b/lib/clerk/rails.rb
@@ -1,3 +1,3 @@
 require "clerk"
 require "clerk/authenticatable"
-require "clerk/railtie"
+require "clerk/railtie" if defined?(Rails::Railtie)

--- a/lib/clerk/railtie.rb
+++ b/lib/clerk/railtie.rb
@@ -6,7 +6,9 @@ module Clerk
   module Rails
     class Railtie < ::Rails::Railtie
       initializer "clerk.configure_rails_initialization" do |app|
-        app.middleware.use Clerk::Rack::Middleware
+        unless ENV["CLERK_SKIP_RAILTIE"]
+          app.middleware.use Clerk::Rack::Middleware
+        end
       end
     end
   end

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "4.0.0.beta5"
+  VERSION = "4.0.0.beta6"
 end

--- a/spec/clerk/sdk_spec.rb
+++ b/spec/clerk/sdk_spec.rb
@@ -145,5 +145,3 @@ RSpec.describe Clerk::SDK do
     end
   end
 end
-
-


### PR DESCRIPTION
Clerk SDK Ruby 4.0.0.beta6

- Allows for users to be able to skip the automatic addition of the Clerk Middleware via Railties.
- Introduces a repeatable release flow.

Fixes ECO-336
Closes #80