### PR TITLE
feat: Enable older versions of Rack

### DIFF
--- a/lib/clerk/rack_middleware.rb
+++ b/lib/clerk/rack_middleware.rb
@@ -63,7 +63,7 @@ module Clerk
       def set_cookie_headers!(headers, cookie_headers)
         cookie_headers.each do |cookie_header|
           cookie_key = parse_cookie_key(cookie_header)
-          cookie = ::Rack::Utils.parse_cookies_header(cookie_header)
+          cookie = ::Clerk::Utils.parse_cookies_header(cookie_header)
           cookie_params = convert_http_cookie_to_cookie_setter_params(cookie_key, cookie)
           ::Rack::Utils.set_cookie_header!(headers, cookie_key, cookie_params)
         end

--- a/lib/clerk/utils.rb
+++ b/lib/clerk/utils.rb
@@ -46,6 +46,24 @@ module Clerk
       def valid_publishable_key_prefix?(publishable_key)
         publishable_key.start_with?("pk_live_", "pk_test_")
       end
+
+      # NOTE: This is a copy of Rack::Utils.parse_cookies_header to allow for
+      # compatibility with older versions of Rack.
+      def parse_cookies_header(value)
+        return {} unless value
+
+        value.split(/; */n).each_with_object({}) do |cookie, cookies|
+          next if cookie.empty?
+          key, value = cookie.split('=', 2)
+          cookies[key] = (unescape(value) rescue value) unless cookies.key?(key)
+        end
+      end
+
+      private 
+
+      def unescape(s, encoding = Encoding::UTF_8)
+        URI.decode_www_form_component(s, encoding)
+      end
     end
   end
 end


### PR DESCRIPTION
`parse_cookies_header` isn't available on older versions of Rack. Replicate in `Clerk::Utils`

Closes #91 