### PR TITLE
fix: Only return lowercase headers (Rack::Lint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1 - 2025-05-21
+
+- fix: Return only lowercase headers (Rack::Lint) [https://github.com/clerk/clerk-sdk-ruby/pull/97]
+
 ## 4.2.0 - 2025-05-20
 
 - feat: Add explicit support for lowercased headers [https://github.com/clerk/clerk-sdk-ruby/pull/93]

--- a/lib/clerk/authenticate_request.rb
+++ b/lib/clerk/authenticate_request.rb
@@ -123,8 +123,8 @@ module Clerk
 
     def resolve_handshake(env)
       headers = {
-        "Access-Control-Allow-Origin" => "null",
-        "Access-Control-Allow-Credentials" => "true"
+        Clerk::ACCESS_CONTROL_ALLOW_ORIGIN_HEADER => "null",
+        Clerk::ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER => "true"
       }
       session_token = nil
 

--- a/lib/clerk/constants.rb
+++ b/lib/clerk/constants.rb
@@ -19,7 +19,10 @@ module Clerk
   SEC_FETCH_DEST_HEADER = "HTTP_SEC_FETCH_DEST"
 
   # headers used in response - should be lowered case and without http prefix
-  LOCATION_HEADER = "Location"
+  ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER = "access-control-allow-credentials"
+  ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "access-control-allow-origin"
+  CONTENT_TYPE_HEADER = "content-type"
+  LOCATION_HEADER = "location"
   SET_COOKIE_HEADER = "set-cookie"
 
   # clerk url related headers

--- a/lib/clerk/proxy.rb
+++ b/lib/clerk/proxy.rb
@@ -99,7 +99,7 @@ module Clerk
 
       [
         403,
-        {"Content-Type" => "application/json"},
+        {Clerk::CONTENT_TYPE_HEADER => "application/json"},
         [StepUp::Reverification.error_payload(config).to_json]
       ]
     end

--- a/lib/clerk/version.rb
+++ b/lib/clerk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clerk
-  VERSION = "4.2.0"
+  VERSION = "4.2.1"
 end

--- a/spec/clerk/authenticate_request_spec.rb
+++ b/spec/clerk/authenticate_request_spec.rb
@@ -584,8 +584,8 @@ RSpec.describe Clerk::AuthenticateRequest do
 
           expect(status).to be_nil
           expect(headers).to eq({
-            "Access-Control-Allow-Credentials" => "true",
-            "Access-Control-Allow-Origin" => "null",
+            Clerk::ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER => "true",
+            Clerk::ACCESS_CONTROL_ALLOW_ORIGIN_HEADER => "null",
             Clerk::LOCATION_HEADER => "http://localhost:3000/admin?",
             Clerk::SET_COOKIE_HEADER => cookie_directives,
             Clerk::AUTH_REASON_HEADER => Clerk::AuthErrorReason::SESSION_TOKEN_MISSING

--- a/spec/clerk/proxy_spec.rb
+++ b/spec/clerk/proxy_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Clerk::Proxy do
 
       expect(response).to be_an(Array)
       expect(response[0]).to eq(403)
-      expect(response[1]).to include("Content-Type" => "application/json")
+      expect(response[1]).to include(Clerk::CONTENT_TYPE_HEADER => "application/json")
       expect(response[2]).to be_an(Array)
     end
 

--- a/spec/clerk/rack_middleware_spec.rb
+++ b/spec/clerk/rack_middleware_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Clerk::Rack::Middleware do
       end
 
       context "when auth_request_headers are present" do
-        let(:auth_request_response) { [nil, {Clerk::SET_COOKIE_HEADER => ["session=bar; path=/; expires=Fri, 15 Jan 2024 00:00:00 GMT; httponly; secure"], "Content-Type" => "application/json"}, nil] }
+        let(:auth_request_response) { [nil, {Clerk::SET_COOKIE_HEADER => ["session=bar; path=/; expires=Fri, 15 Jan 2024 00:00:00 GMT; httponly; secure"], Clerk::CONTENT_TYPE_HEADER => "application/json"}, nil] }
         let(:app_response) { [200, {Clerk::SET_COOKIE_HEADER => ["session=foo; path=/; expires=Wed, 13 Jan 2024 00:00:00 GMT; httponly; secure"]}, "OK"] }
 
         it "should remove the `set-cookie` header to avoid overriding existing cookies set by other middleware" do
@@ -85,7 +85,7 @@ RSpec.describe Clerk::Rack::Middleware do
 
           expect(status).to eq(200)
           expect(headers).to eq({
-            "Content-Type" => "application/json", 
+            Clerk::CONTENT_TYPE_HEADER => "application/json",
             Clerk::SET_COOKIE_HEADER => [
               "session=foo; path=/; expires=Wed, 13 Jan 2024 00:00:00 GMT; httponly; secure", 
               "session=bar; path=/; expires=Mon, 15 Jan 2024 00:00:00 GMT; secure; httponly"
@@ -220,7 +220,7 @@ RSpec.describe Clerk::Rack::Reverification do
     end
 
     context "when reverification is needed" do
-      let(:reverification_response) { [302, {"Location" => "/reverify"}, []] }
+      let(:reverification_response) { [302, {Clerk::LOCATION_HEADER => "/reverify"}, []] }
 
       it "returns reverification response" do
         allow(clerk_instance).to receive(:user_needs_reverification?).and_return(true)


### PR DESCRIPTION
`Rack::Lint` fails if included elsewhere in the middleware stack.