### PR TITLE
Upgrade ruby-jwt dependency to version 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       clerk-http-client (~> 2.0)
       concurrent-ruby (~> 1.1)
       faraday (>= 1.4.1, < 3.0)
-      jwt (~> 2.5)
+      jwt (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -97,7 +97,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.9.1)
-    jwt (2.10.1)
+    jwt (3.1.1)
       base64
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", ">= 1.4.1", "< 3.0"
-  spec.add_dependency "jwt", '~> 2.5'
+  spec.add_dependency "jwt", '~> 3.0'
   spec.add_dependency "clerk-http-client", "~> 2.0"
   spec.add_dependency "concurrent-ruby", "~> 1.1"
 

--- a/lib/clerk/authenticate_request.rb
+++ b/lib/clerk/authenticate_request.rb
@@ -223,7 +223,7 @@ module Clerk
         sdk.verify_token(token, **opts)
       rescue JWT::ExpiredSignature, JWT::InvalidIatError => e
         raise e
-      rescue JWT::DecodeError, JWT::RequiredDependencyError => _
+      rescue JWT::DecodeError => _
         false
       end
     end

--- a/spec/clerk/authenticate_request_spec.rb
+++ b/spec/clerk/authenticate_request_spec.rb
@@ -436,11 +436,6 @@ RSpec.describe Clerk::AuthenticateRequest do
       expect(instance.send(:verify_token, "invalid_token")).to be false
     end
 
-    it "should return false if the token has a required dependency error" do
-      expect(sdk).to receive(:verify_token).and_raise(JWT::RequiredDependencyError)
-      expect(instance.send(:verify_token, "invalid_token")).to be false
-    end
-
     it "should re-raise the error if the token is expired" do
       expect(sdk).to receive(:verify_token).and_raise(JWT::ExpiredSignature)
       expect { instance.send(:verify_token, "invalid_token") }.to raise_error(JWT::ExpiredSignature)


### PR DESCRIPTION
The core gem was upgraded to version 3 a couple of weeks ago https://github.com/jwt/ruby-jwt/tree/v3.0.0.

Removed the RequiredDependencyError constant as that has been removed in the gem itself as part of https://github.com/jwt/ruby-jwt/pull/676