### PR TITLE
chore: Bump minimum required ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   universal-darwin-21
   x86_64-linux
 

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Client SDK for the Clerk"
   spec.homepage      = "https://github.com/clerk/clerk-sdk-ruby"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/clerk/clerk-sdk-ruby"


### PR DESCRIPTION
Ruby 3.2.0 is the oldest version that's still supported, everything older than that is EOL.

Some Dependabot updates are blocked because the new gem versions don't support Ruby 2.4 which is out of support since 2020-03-31. See https://www.ruby-lang.org/en/downloads/branches/