### PR TITLE
fix: Remove rerun/ffi dependencies

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,13 +5,13 @@ management:
   docVersion: "2025-11-10"
   speakeasyVersion: 1.692.0
   generationVersion: 2.797.1
-  releaseVersion: 0.0.37
-  configChecksum: 622132e742fa2fefae9e7c683918c3ac
+  releaseVersion: 0.0.38
+  configChecksum: 304fbf704853b3398841aac5db693721
   published: true
 persistentEdits:
-  generation_id: 5aa67223-eb84-46ca-ba36-fa990bedf32d
-  pristine_commit_hash: 74aa1f3dc05f5ad88dc497ff44c623f661b13ca3
-  pristine_tree_hash: c5d1e48611ee86e58f45506ac96ad8dcc94fedb0
+  generation_id: d6b6455d-8e24-4fc5-a808-86fe86fefe52
+  pristine_commit_hash: 2638e9d051e5f60e8d63ec1ac504b711028906f9
+  pristine_tree_hash: f7071dfddadd974ac61e337347b072fbb246ab01
 features:
   ruby:
     additionalProperties: 0.1.0
@@ -44,8 +44,8 @@ trackedFiles:
     pristine_git_object: b0ea40558f3ca80dcf7d30b159d34a1e5ab33440
   Gemfile.lock:
     id: 21fb5836b499
-    last_write_checksum: sha1:28fa4853f9adbd402047f4bf337a730f7cc2ace7
-    pristine_git_object: 2059b216cba4c0aa833ec19fbd42cb80290f7d9d
+    last_write_checksum: sha1:2b3e549f806622fdd69f8e0aad913de16cb4ea36
+    pristine_git_object: fca35ed743358b165a6e098a76cb897429b6567d
   Rakefile:
     id: 44b7fa1ba503
     last_write_checksum: sha1:3bb027e7620352086cf7ac562ce0c2a1473763bd
@@ -56,8 +56,8 @@ trackedFiles:
     pristine_git_object: a1725c79d0ea4c296b418b677721e5c151ba9c7d
   clerk-sdk-ruby.gemspec:
     id: 1d24faa8ee4c
-    last_write_checksum: sha1:ec27be3b8e1bcd154b9c9a7411b09c2dd190c45a
-    pristine_git_object: f51247fa2ab4595ece1835a26573797d9bc170ed
+    last_write_checksum: sha1:1792e0c87893409cde562007e55a511582bb8e6f
+    pristine_git_object: 3314160e86b1ae210017b9c648fae192758e3008
   docs/models/components/actortoken.md:
     id: 6f567bd2f98e
     last_write_checksum: sha1:20b5bcc73de9dd30005ace61e79932376c978594
@@ -10976,8 +10976,8 @@ trackedFiles:
     pristine_git_object: a9439db9cbc91b3abef17baf0d438a99a9190cf0
   lib/clerk/sdkconfiguration.rb:
     id: 005b930c709e
-    last_write_checksum: sha1:5dd80ae85d657dee81baac985bde2740c67ca6e9
-    pristine_git_object: bd247ee35db874a571a1f829b94d0e2d119be49e
+    last_write_checksum: sha1:66f8fd9194238b32713cb68f415a7413c2de4686
+    pristine_git_object: 31fc5afd90919e3232267d6e167750f2203fc7c1
   lib/clerk/sdkconfiguration.rbi:
     id: c7163e8cf2ca
     last_write_checksum: sha1:fea1767a154b4575f107e7dda123f1cc89a1c581

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -29,7 +29,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 ruby:
-  version: 0.0.37
+  version: 0.0.38
   additionalDependencies:
     development:
       activesupport: ~> 8.0.0
@@ -38,7 +38,6 @@ ruby:
       rack: ~> 3.1.18
       rackup: ~> 2.2
       rake: ~> 13.0
-      rerun: ~> 0.14
       sinatra: ~> 4.1
     runtime:
       concurrent-ruby: ~> 1.3.5

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -14,7 +14,7 @@ targets:
         sourceRevisionDigest: sha256:0b293b4705887ab150918e77e54c1ea643104cd73bc6efd21183393597505faf
         sourceBlobDigest: sha256:93cae508ba959aac63e75b559c3f68472312b22dfa907c3124a6161343b3b8af
         codeSamplesNamespace: clerk-oas-ruby-code-samples
-        codeSamplesRevisionDigest: sha256:ce793eedc32f5bc87832b3c39765af150003ab4a7789d20ea9d3d11e13fc2fe6
+        codeSamplesRevisionDigest: sha256:89c7211e03d191a0bd620e2f5f36fede50bb27b68326419135850d44385bebe4
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clerk-sdk-ruby (0.0.37)
+    clerk-sdk-ruby (0.0.38)
       base64 (>= 0.2.0, < 1.0)
       concurrent-ruby (~> 1.3.5)
       faraday
@@ -43,9 +43,6 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
-    ffi (1.17.3-aarch64-linux-gnu)
-    ffi (1.17.3-arm64-darwin)
-    ffi (1.17.3-x86_64-linux-gnu)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.8.2)
@@ -53,10 +50,6 @@ GEM
       base64
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
-    listen (3.10.0)
-      logger
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.6)
     minitest (6.0.1)
       prism (~> 1.5)
@@ -88,12 +81,7 @@ GEM
       rack (>= 3)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     regexp_parser (2.10.0)
-    rerun (0.14.0)
-      listen (~> 3.0)
     rubocop (1.73.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -146,7 +134,6 @@ DEPENDENCIES
   rack (~> 3.1.18)
   rackup (~> 2.2)
   rake (~> 13.0)
-  rerun (~> 0.14)
   rubocop (~> 1.73.2)
   rubocop-minitest (~> 0.37.1)
   sinatra (~> 4.1)

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ rails:
 rails-api:
 	@cd apps/rails-api && bin/rails server
 
+# Rerun must be installed globally:
+# gem install --system rerun
 rack:
 	rerun --dir lib,apps/rack --pattern '**/*.{rb,ru}' -- bundle exec puma apps/rack/config.ru -p 3000
 

--- a/clerk-sdk-ruby.gemspec
+++ b/clerk-sdk-ruby.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name        = 'clerk-sdk-ruby'
-  s.version     = '0.0.37'
+  s.version     = '0.0.38'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['Apache-2.0']
   s.summary     = ''
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rack', '~> 3.1.18')
   s.add_development_dependency('rackup', '~> 2.2')
   s.add_development_dependency('rake', '~> 13.0')
-  s.add_development_dependency('rerun', '~> 0.14')
   s.add_development_dependency('rubocop', '~> 1.73.2')
   s.add_development_dependency('rubocop-minitest', '~> 0.37.1')
   s.add_development_dependency('sinatra', '~> 4.1')

--- a/lib/clerk/sdkconfiguration.rb
+++ b/lib/clerk/sdkconfiguration.rb
@@ -77,9 +77,9 @@ module Clerk
       end
       @language = 'ruby'
       @openapi_doc_version = '2025-11-10'
-      @sdk_version = '0.0.37'
+      @sdk_version = '0.0.38'
       @gen_version = '2.797.1'
-      @user_agent = 'speakeasy-sdk/ruby 0.0.37 2.797.1 2025-11-10 clerk-sdk-ruby'
+      @user_agent = 'speakeasy-sdk/ruby 0.0.38 2.797.1 2025-11-10 clerk-sdk-ruby'
     end
 
     


### PR DESCRIPTION
Removes `rerun`/`ffi` dependencies as they were having issues on GitHub Actions and aren't required.