### PR TITLE
fix: README table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ $ bundle install
 
 The SDK automatically reads these environment variables:
 
-| Variable	            | Description                                  |
-------------------------------------------------------------------------
-| CLERK_SECRET_KEY	    | Your Clerk secret key (starts with sk_)      |
-| CLERK_PUBLISHABLE_KEY	| Your Clerk publishable key (starts with pk_) |
-| CLERK_SIGN_IN_URL	URL | to redirect unauthenticated users            |
-| CLERK_SIGN_UP_URL	URL | for new user registration                    |
-| CLERK_SIGN_OUT_URL	  | URL for sign out                             |
+| Variable	             | Description                                   |
+|-----------------------|-----------------------------------------------|
+| CLERK_SECRET_KEY	     | Your Clerk secret key (starts with sk_)       |
+| CLERK_PUBLISHABLE_KEY	| Your Clerk publishable key (starts with pk_)  |
+| CLERK_SIGN_IN_URL	URL | to redirect unauthenticated users             |
+| CLERK_SIGN_UP_URL	URL | for new user registration                     |
+| CLERK_SIGN_OUT_URL	   | URL for sign out                              |
 
 ### Programmatic Configuration
 


### PR DESCRIPTION
current table in README is malformed

<img width="1002" height="436" alt="Screenshot 2026-01-25 at 19 52 26" src="https://github.com/user-attachments/assets/26e93670-b070-4930-96ba-e4def4feea34" />

