### PR TITLE
chore: Move to trusted publishing

### DIFF
--- a/.github/workflows/rubygems_mint_token.yaml
+++ b/.github/workflows/rubygems_mint_token.yaml
@@ -1,0 +1,24 @@
+name: Mint RubyGems Token
+on:
+  workflow_call:
+    outputs:
+      rubygems_token:
+        description: Minted RubyGems API token via OIDC
+        value: ${{ jobs.mint.outputs.rubygems_token }}
+jobs:
+  mint:
+    name: Mint RubyGems token
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure RubyGems Credentials
+        id: configure
+        uses: rubygems/configure-rubygems-credentials@main
+        with:
+          trusted-publisher: true
+      - name: Export token for Speakeasy
+        id: output-token
+        run: echo "rubygems_token=$RUBYGEMS_API_KEY" >> "$GITHUB_OUTPUT"
+    outputs:
+      rubygems_token: ${{ steps.output-token.outputs.rubygems_token }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -22,7 +22,10 @@ permissions:
       - labeled
       - unlabeled
 jobs:
+  mint_rubygems_token:
+    uses: ./.github/workflows/rubygems_mint_token.yaml
   generate:
+    needs: mint_rubygems_token
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}
@@ -30,5 +33,5 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      rubygems_auth_token: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+      rubygems_auth_token: ${{ needs.mint_rubygems_token.outputs.rubygems_token }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -13,11 +13,14 @@ permissions:
       - .speakeasy/gen.lock
   workflow_dispatch: {}
 jobs:
+  mint_rubygems_token:
+    uses: ./.github/workflows/rubygems_mint_token.yaml
   publish:
+    needs: mint_rubygems_token
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
     with:
       target: clerk
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      rubygems_auth_token: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+      rubygems_auth_token: ${{ needs.mint_rubygems_token.outputs.rubygems_token }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
Trying to replicate what we did in https://github.com/clerk/clerk-sdk-python to combine OIDC trusted publishing with Speakeasy