### PR TITLE
chore: Update `jwt` dependency to v3

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -42,7 +42,7 @@ ruby:
       sinatra: ~> 4.1
     runtime:
       concurrent-ruby: ~> 1.3.5
-      jwt: ~> 2.5
+      jwt: ~> 3.0
   author: Speakeasy
   baseErrorName: ClerkError
   clientServerStatusCodesAsErrors: true


### PR DESCRIPTION
Updates `jwt` dependency from `~> 2.5` to `~> 3.0`.

It will require a forced re-generation and publish once merged.