### PR TITLE
Bugfix missing symbol breaks variable usage

### DIFF
--- a/lib/clerk/proxy.rb
+++ b/lib/clerk/proxy.rb
@@ -65,7 +65,7 @@ module Clerk
     def user_reverified?(params)
       return false unless user?
 
-      fva = session_claims['fva']
+      fva = @session_claims['fva']
 
       # the feature is disabled
       return true if fva.nil?


### PR DESCRIPTION
Missing @ symbol breaks many methods when used in versions 5 and up