### PR TITLE
fix(sdk): Scope the JWKS cache per Clerk instance

### DIFF
--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -3,6 +3,7 @@
 require 'clerk/jwks_cache'
 require 'clerk/openapiclient'
 # require 'clerk/version'
+require 'digest'
 require 'jwt'
 
 module Clerk
@@ -16,16 +17,33 @@ module Clerk
     # How often (in seconds) should JWKs be refreshed
     JWKS_CACHE_LIFETIME = 3600 # 1 hour
 
+    # One JWKS cache per Clerk instance. A single process-wide cache would let a
+    # token minted by one instance verify against another, since the keys it
+    # holds are whichever instance refreshed last and no issuer check runs.
+    # The cache still outlives individual SDK objects, because
+    # `authenticate_request` builds a fresh SDK per request.
     # rubocop:disable Style/ClassVars
-    @@jwks_cache = JWKSCache.new(JWKS_CACHE_LIFETIME)
+    @@jwks_caches = {}
+    @@jwks_caches_mutex = Mutex.new
     # rubocop:enable Style/ClassVars
-    
-    def self.jwks_cache
-      @@jwks_cache
+
+    # Returns the JWKS cache for a single Clerk instance. `scope` must identify
+    # that instance; see #jwks_cache_scope.
+    def self.jwks_cache(scope)
+      @@jwks_caches_mutex.synchronize do
+        @@jwks_caches[scope] ||= JWKSCache.new(JWKS_CACHE_LIFETIME)
+      end
     end
+
+    # Opaque identifier for the Clerk instance this SDK talks to. The secret key
+    # is hashed so it is never retained as a cache key.
+    attr_reader :jwks_cache_scope
 
     def initialize(client: nil, retry_config: nil, timeout_ms: nil, secret_key: nil, security_source: nil, server_idx: nil, server_url: nil, url_params: nil)
       secret_key ||= Clerk.configuration.secret_key
+      @jwks_cache_scope = Digest::SHA256.hexdigest(
+        [server_url, server_idx, secret_key].join("\0")
+      )
       super(
         client: client,
         retry_config: retry_config,
@@ -56,7 +74,7 @@ module Clerk
       jwk_loader = lambda do |options|
         # JWT.decode requires that the 'keys' key in the Hash is a symbol (as
         # opposed to a string which our SDK returns by default)
-        {keys: SDK.jwks_cache.fetch(self, kid_not_found: options[:invalidate] || options[:kid_not_found], force_refresh: force_refresh_jwks)}
+        {keys: SDK.jwks_cache(@jwks_cache_scope).fetch(self, kid_not_found: options[:invalidate] || options[:kid_not_found], force_refresh: force_refresh_jwks)}
       end
 
       begin

--- a/test/clerk/jwks_cache_scoping_test.rb
+++ b/test/clerk/jwks_cache_scoping_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'faraday'
+require 'faraday/adapter/test'
+require 'json'
+require 'jwt'
+require 'minitest/autorun'
+require 'openssl'
+require_relative '../../lib/clerk'
+
+# Regression test for AISEC-84. The JWKS cache was a single class variable
+# shared by every Clerk::SDK in the process, and verify_token performs no
+# issuer check. While the cache held one instance's keys, a token minted by
+# that instance verified against any other instance's SDK.
+class JwksCacheScopingTest < Minitest::Test
+  Tenant = Struct.new(:sdk, :token, :fetches)
+
+  def test_cached_keys_are_not_served_to_another_instance
+    tenant_a = build_tenant('tenant_a')
+    tenant_b = build_tenant('tenant_b')
+
+    # A legitimate tenant-B verification loads tenant B's keys.
+    claims = tenant_b.sdk.verify_token(tenant_b.token)
+    assert_equal 'user_tenant_b', claims['sub']
+    assert_equal ['tenant_b'], tenant_b.fetches
+
+    # The same token under tenant A must not resolve against tenant B's keys.
+    assert_raises(JWT::DecodeError) do
+      tenant_a.sdk.verify_token(tenant_b.token)
+    end
+    refute_empty tenant_a.fetches, 'tenant A must fetch its own JWKS'
+  end
+
+  def test_scope_differs_per_secret_key
+    sdk_a = ::Clerk::SDK.new(secret_key: 'sk_test_a', server_url: 'https://api.clerk.com/v1')
+    sdk_b = ::Clerk::SDK.new(secret_key: 'sk_test_b', server_url: 'https://api.clerk.com/v1')
+    sdk_a_again = ::Clerk::SDK.new(secret_key: 'sk_test_a', server_url: 'https://api.clerk.com/v1')
+
+    refute_equal sdk_a.jwks_cache_scope, sdk_b.jwks_cache_scope
+    # The cache must still be shared across SDKs for the same instance, since
+    # authenticate_request builds a fresh SDK per request.
+    assert_equal sdk_a.jwks_cache_scope, sdk_a_again.jwks_cache_scope
+    assert_same ::Clerk::SDK.jwks_cache(sdk_a.jwks_cache_scope),
+                ::Clerk::SDK.jwks_cache(sdk_a_again.jwks_cache_scope)
+  end
+
+  private
+
+  def build_tenant(name)
+    key = OpenSSL::PKey::RSA.generate(2048)
+    kid = "ins_#{name}"
+    jwk = {
+      kty: 'RSA', use: 'sig', alg: 'RS256', kid: kid,
+      n: b64(key.n.to_s(2)),
+      e: b64(key.e.to_s(2))
+    }
+
+    fetches = []
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.get('/v1/jwks') do
+      fetches << name
+      [200, {'Content-Type' => 'application/json'}, JSON.generate(keys: [jwk])]
+    end
+    client = Faraday.new { |builder| builder.adapter :test, stubs }
+
+    sdk = ::Clerk::SDK.new(
+      secret_key: "sk_test_#{name}",
+      client: client,
+      server_url: 'https://api.clerk.com/v1'
+    )
+    token = JWT.encode(
+      {sub: "user_#{name}", exp: Time.now.to_i + 3600},
+      key, 'RS256', {kid: kid}
+    )
+
+    Tenant.new(sdk, token, fetches)
+  end
+
+  def b64(bytes)
+    Base64.urlsafe_encode64(bytes, padding: false)
+  end
+end


### PR DESCRIPTION
The JWKS cache was a single `@@jwks_cache` class variable shared by every Clerk::SDK in the process, and `verify_token` performs no issuer check. `JWKSCache#fetch` reassigns the keyset on refresh, so while the cache held one instance's keys, a session token minted by that instance verified against any other instance's SDK and returned its claims as authenticated.

The cache is now looked up by a hash of the server URL and secret key. It still outlives individual SDK objects, since `authenticate_request` builds a fresh SDK per request, but keys are never shared across instances.

`Clerk::SDK.jwks_cache` now requires a scope argument.

Fixes AISEC-84