### PR TITLE
fix(sdk): fail closed on malformed v2 feature-permission masks

### DIFF
--- a/lib/clerk/sdk.rb
+++ b/lib/clerk/sdk.rb
@@ -90,6 +90,10 @@ module Clerk
 
     private
 
+    # Decodes the `fea`/`o.per`/`o.fpm` triple of a v2 session token into
+    # `org:<feature>:<action>` permission strings. Anything that cannot be
+    # decoded with confidence is skipped rather than guessed at, so malformed
+    # claims can only ever narrow the permission set, never widen it.
     def compute_org_permissions_from_v2_token(claims)
       features    = claims['fea'] ? claims['fea'].split(',') : []
       permissions = claims['o']['per'] ? claims['o']['per'].split(',') : []
@@ -97,12 +101,28 @@ module Clerk
       org_permissions = []
 
       mappings.each_with_index do |mapping, i|
+        # Each mapping is positionally aligned to a feature. A mapping without a
+        # matching feature entry cannot be attributed to anything, so skip it.
+        next if features[i].nil?
+
         scope, feature = features[i].split(':')
 
+        next if scope.nil? || feature.nil? # malformed feature entry
         next if !scope.include?('o') # not an orgs-related permission
+        # Only a non-negative decimal integer is a valid mask. The backend builds
+        # these masks in a signed 64-bit integer, so an action at index 63
+        # overflows into a negative value whose binary representation is a minus
+        # sign followed by ones ("-111...1"); walking that string character by
+        # character would grant every one of those bits. Reject anything that is
+        # not a plain non-negative decimal, mirroring `decimalToBinaryBits` in
+        # @clerk/shared, which fails closed the same way.
+        next if !/\A\d+\z/.match?(mapping)
 
         mapping.to_i.to_s(2).reverse.each_char.each_with_index do |bit, j|
-          org_permissions << "org:#{feature}:#{permissions[j]}" if bit == '1'
+          next if bit != '1'
+          next if permissions[j].nil? # mask has more bits than the permission vocabulary
+
+          org_permissions << "org:#{feature}:#{permissions[j]}"
         end
       end
 

--- a/test/clerk/org_permissions_v2_test.rb
+++ b/test/clerk/org_permissions_v2_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../../lib/clerk'
+
+module Clerk
+  # Coverage for Clerk::SDK#compute_org_permissions_from_v2_token, which decodes
+  # the `fea` / `o.per` / `o.fpm` triple of a v2 session token into
+  # `org:<feature>:<action>` strings.
+  class OrgPermissionsV2Test < Minitest::Test
+    ACTIONS = (0...64).map { |n| "act_#{n}" }.freeze
+
+    def sdk
+      @sdk ||= Clerk::SDK.new(secret_key: 'sk_test_not_used')
+    end
+
+    def permissions_for(fea:, per:, fpm:)
+      claims = {'fea' => fea, 'o' => {'per' => per, 'fpm' => fpm}}
+      sdk.send(:compute_org_permissions_from_v2_token, claims)
+    end
+
+    # --- happy path (regression guard) ----------------------------------------
+
+    def test_small_masks_decode_with_bit_zero_least_significant
+      result = permissions_for(
+        fea: 'o:leads,o:whatsapp',
+        per: 'chat_read,chat_send,connect,view_history',
+        fpm: '3,10'
+      )
+
+      assert_equal ['org:leads:chat_read', 'org:leads:chat_send',
+                    'org:whatsapp:chat_send', 'org:whatsapp:view_history'], result
+    end
+
+    def test_zero_mask_grants_nothing
+      assert_empty permissions_for(fea: 'o:leads', per: 'chat_read,chat_send', fpm: '0')
+    end
+
+    def test_non_org_scoped_features_are_skipped
+      result = permissions_for(
+        fea: 'u:billing,o:leads',
+        per: 'chat_read,chat_send',
+        fpm: '3,1'
+      )
+
+      assert_equal ['org:leads:chat_read'], result
+    end
+
+    # --- wide masks ------------------------------------------------------------
+
+    def test_mask_with_bit_62_set
+      result = permissions_for(fea: 'o:leads', per: ACTIONS.join(','), fpm: (2**62).to_s)
+
+      assert_equal ['org:leads:act_62'], result
+    end
+
+    def test_positive_bignum_mask_with_bit_63_set
+      # 2**63 + 1 -- above the signed 64-bit range, but Ruby Integers are
+      # arbitrary-precision so this must still decode to indices 0 and 63.
+      result = permissions_for(fea: 'o:leads', per: ACTIONS.join(','), fpm: '9223372036854775809')
+
+      assert_equal ['org:leads:act_0', 'org:leads:act_63'], result
+    end
+
+    # --- the security regression: negative masks must fail closed --------------
+
+    def test_negative_mask_grants_nothing
+      # A signed 64-bit overflow on the producing side yields a negative mask.
+      # `(-9223372036854775807).to_s(2)` is "-111...1", which -- walked character
+      # by character -- would otherwise grant 63 permissions.
+      result = permissions_for(fea: 'o:leads', per: ACTIONS.join(','), fpm: '-9223372036854775807')
+
+      assert_empty result
+    end
+
+    def test_negative_mask_does_not_affect_other_features
+      result = permissions_for(
+        fea: 'o:leads,o:whatsapp',
+        per: ACTIONS.join(','),
+        fpm: '3,-9223372036854775807'
+      )
+
+      assert_equal ['org:leads:act_0', 'org:leads:act_1'], result
+    end
+
+    def test_non_numeric_masks_grant_nothing
+      ['abc', '1e3', '0x10', ' 3', '3 ', '1.5', '+3', ''].each do |mask|
+        assert_empty permissions_for(fea: 'o:leads', per: ACTIONS.join(','), fpm: mask),
+                     "expected mask #{mask.inspect} to grant nothing"
+      end
+    end
+
+    # --- malformed claims must not raise ---------------------------------------
+
+    def test_more_mappings_than_features_does_not_raise
+      result = permissions_for(fea: 'o:leads', per: 'chat_read,chat_send', fpm: '1,3,7')
+
+      assert_equal ['org:leads:chat_read'], result
+    end
+
+    def test_feature_without_a_scope_separator_does_not_raise
+      result = permissions_for(fea: 'leads,o:whatsapp', per: 'chat_read', fpm: '1,1')
+
+      assert_equal ['org:whatsapp:chat_read'], result
+    end
+
+    def test_missing_claims_do_not_raise
+      assert_empty permissions_for(fea: nil, per: nil, fpm: nil)
+      assert_empty permissions_for(fea: 'o:leads', per: nil, fpm: '3')
+      assert_empty permissions_for(fea: nil, per: 'chat_read', fpm: '3')
+    end
+
+    # --- masks wider than the permission vocabulary ----------------------------
+
+    def test_mask_wider_than_permission_list_does_not_emit_empty_permissions
+      # 0b1111 against a two-action vocabulary: only the first two bits map.
+      result = permissions_for(fea: 'o:leads', per: 'chat_read,chat_send', fpm: '15')
+
+      assert_equal ['org:leads:chat_read', 'org:leads:chat_send'], result
+      refute(result.any? { |permission| permission.end_with?(':') },
+             "expected no permissions with an empty action name, got #{result.inspect}")
+    end
+
+    def test_high_bit_beyond_permission_list_is_ignored
+      result = permissions_for(fea: 'o:leads', per: 'chat_read', fpm: (2**63 | 1).to_s)
+
+      assert_equal ['org:leads:chat_read'], result
+    end
+  end
+end


### PR DESCRIPTION
Fixes the Ruby half of [CORE-3701](https://linear.app/clerk/issue/CORE-3701/fix-jwt-v2-custom-permission-mask-overflow).

## Problem

`compute_org_permissions_from_v2_token` decodes each `o.fpm` mask with `mapping.to_i.to_s(2).reverse`. That is correct for a non-negative mask, but **fails open** on a negative one.

The backend currently builds these masks in a signed 64-bit integer, so an action at bit index 63 overflows into a negative value. Ruby renders `(-9223372036854775807).to_s(2)` as a minus sign followed by 63 ones — walking that string character by character grants every one of those bits.

Reproduced: `fpm: '3,-9223372036854775807'` against a 4-action vocabulary returned **65** permissions — 2 legitimate, 63 spurious, 59 of them malformed `"org:whatsapp:"` entries with no action name.

Of the four decoders, this is the only one that fails open. `@clerk/shared` rejects the leading `-` via `/^\d+$/`, and the Go SDK's loop condition happens to fail closed.

## Fix

Three guards, all in the fail-closed direction:

1. `/\A\d+\z/` on the mask — only a non-negative decimal integer is a valid bitfield. Mirrors `decimalToBinaryBits` in `@clerk/shared`.
2. `features[i].nil?` — `fpm` with more entries than `fea` raised `NoMethodError: undefined method 'split' for nil`.
3. `permissions[j].nil?` — a mask with more bits than the vocabulary emitted malformed `"org:feature:"` strings.

Ruby Integers are arbitrary-precision, so large **positive** masks already decode correctly. No width cap is added — only negatives and non-numerics are rejected.

Positional `fpm[i]` ↔ `features[i]` alignment, the `scope.include?('o')` filter, the output format, and bit-0-is-least-significant ordering are all unchanged.

`lib/clerk/sdk.rb` is in `.genignore` under "Custom Files", so this is hand-written and no regeneration is involved.

## Tests

New `test/clerk/org_permissions_v2_test.rb` — 13 minitest cases covering normal masks, bit 62, a positive bignum at bit 63, negative masks granting nothing, over-long `fpm`, and over-wide masks. Against the unpatched `sdk.rb` these give 6 failures and 1 error; patched, all 13 pass.

## Two unrelated things found

- `spec/` is dead code — `spec/clerk/authenticate_request_spec.rb` requires a `spec_helper` that does not exist, and rspec is in neither the gemspec nor `Gemfile.lock`. Tests here go in `test/`.
- `bundle exec rake test` is broken on Ruby 4.0 independently of this change: `ostruct` was dropped from default gems and `lib/clerk/authenticate_context.rb:3` requires it without the gemspec declaring it. Reproduces with this branch stashed. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)